### PR TITLE
Implement Firebase login and sign up

### DIFF
--- a/flutter_application_sajindongnae/lib/main.dart
+++ b/flutter_application_sajindongnae/lib/main.dart
@@ -1,11 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'screen/post/list.dart';
 import 'package:flutter_application_sajindongnae/screen/photo/photo_sell.dart';
 import 'package:flutter_application_sajindongnae/screen/chat/chat_list.dart';
 import 'package:flutter_application_sajindongnae/screen/mypage.dart';
+import 'package:flutter_application_sajindongnae/screen/auth/login_screen.dart';
 import 'component/bottom_nav.dart'; // bottom_nav.dart에서 UI 분리한 하단바
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(const MyApp()); // MyApp 클래스부터 어플 시작
 }
 
@@ -14,8 +19,21 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: MainPage(), // 시작 시 보여줄 화면
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasData) {
+            return const MainPage();
+          } else {
+            return const LoginScreen();
+          }
+        },
+      ),
     );
   }
 }

--- a/flutter_application_sajindongnae/lib/models/user_model.dart
+++ b/flutter_application_sajindongnae/lib/models/user_model.dart
@@ -1,0 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+class UserModel {
+  final String uid;
+  final String email;
+  final String nickname;
+  final DateTime createdAt;
+
+  UserModel({
+    required this.uid,
+    required this.email,
+    required this.nickname,
+    required this.createdAt,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'uid': uid,
+      'email': email,
+      'nickname': nickname,
+      'createdAt': createdAt,
+    };
+  }
+
+  factory UserModel.fromMap(Map<String, dynamic> map) {
+    return UserModel(
+      uid: map['uid'],
+      email: map['email'],
+      nickname: map['nickname'],
+      createdAt: (map['createdAt'] as Timestamp).toDate(),
+    );
+  }
+}

--- a/flutter_application_sajindongnae/lib/screen/auth/login_screen.dart
+++ b/flutter_application_sajindongnae/lib/screen/auth/login_screen.dart
@@ -1,0 +1,74 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'register_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  bool isLoading = false;
+
+  Future<void> _login() async {
+    setState(() => isLoading = true);
+    try {
+      await FirebaseAuth.instance.signInWithEmailAndPassword(
+        email: emailController.text.trim(),
+        password: passwordController.text.trim(),
+      );
+    } on FirebaseAuthException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message ?? '로그인 실패')),
+      );
+    } finally {
+      setState(() => isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('로그인')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: '이메일'),
+            ),
+            TextField(
+              controller: passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: '비밀번호'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: isLoading ? null : _login,
+              child: isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('로그인'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => const RegisterScreen(),
+                  ),
+                );
+              },
+              child: const Text('회원가입'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_application_sajindongnae/lib/screen/auth/register_screen.dart
+++ b/flutter_application_sajindongnae/lib/screen/auth/register_screen.dart
@@ -1,0 +1,76 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+class RegisterScreen extends StatefulWidget {
+  const RegisterScreen({super.key});
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
+  final TextEditingController nicknameController = TextEditingController();
+  bool isLoading = false;
+
+  Future<void> _register() async {
+    setState(() => isLoading = true);
+    try {
+      final credential = await FirebaseAuth.instance.createUserWithEmailAndPassword(
+        email: emailController.text.trim(),
+        password: passwordController.text.trim(),
+      );
+
+      await FirebaseFirestore.instance.collection('users').doc(credential.user!.uid).set({
+        'uid': credential.user!.uid,
+        'email': emailController.text.trim(),
+        'nickname': nicknameController.text.trim(),
+        'createdAt': DateTime.now(),
+      });
+
+      if (mounted) Navigator.pop(context);
+    } on FirebaseAuthException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message ?? '회원가입 실패')),
+      );
+    } finally {
+      setState(() => isLoading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('회원가입')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailController,
+              decoration: const InputDecoration(labelText: '이메일'),
+            ),
+            TextField(
+              controller: passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: '비밀번호'),
+            ),
+            TextField(
+              controller: nicknameController,
+              decoration: const InputDecoration(labelText: '닉네임'),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: isLoading ? null : _register,
+              child: isLoading
+                  ? const CircularProgressIndicator()
+                  : const Text('가입하기'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_application_sajindongnae/lib/screen/mypage.dart
+++ b/flutter_application_sajindongnae/lib/screen/mypage.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:http/http.dart' as http;
-import 'package:flutter_application_sajindongnae/component/search.dart'; 
+import 'package:flutter_application_sajindongnae/component/search.dart';
 
 
 class MyPageScreen extends StatefulWidget {
@@ -14,7 +15,17 @@ class _MyPageScreenState extends State<MyPageScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('마이페이지지'),),
+      appBar: AppBar(
+        title: const Text('마이페이지'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () async {
+              await FirebaseAuth.instance.signOut();
+            },
+          )
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- integrate Firebase initialization in main.dart and show login screen when not authenticated
- create `UserModel` to describe account data
- add sign-up and login screens using Firebase Auth and Firestore
- enable logout from the MyPage screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684122381fe0832aa6624f4bc9d5c5fd