### PR TITLE
Fix auth flow and add Google sign in

### DIFF
--- a/flutter_application_sajindongnae/android/app/src/main/AndroidManifest.xml
+++ b/flutter_application_sajindongnae/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Required permissions for location, storage and camera access -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:label="flutter_application_sajindongnae"
         android:name="${applicationName}"

--- a/flutter_application_sajindongnae/lib/screen/auth/login_screen.dart
+++ b/flutter_application_sajindongnae/lib/screen/auth/login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:google_sign_in/google_sign_in.dart';
 import 'register_screen.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -30,6 +31,30 @@ class _LoginScreenState extends State<LoginScreen> {
     }
   }
 
+  Future<void> _googleLogin() async {
+    setState(() => isLoading = true);
+    try {
+      final googleUser = await GoogleSignIn().signIn();
+      if (googleUser == null) {
+        setState(() => isLoading = false);
+        return;
+      }
+
+      final googleAuth = await googleUser.authentication;
+      final credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
+        idToken: googleAuth.idToken,
+      );
+      await FirebaseAuth.instance.signInWithCredential(credential);
+    } on FirebaseAuthException catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(e.message ?? '구글 로그인 실패')),
+      );
+    } finally {
+      setState(() => isLoading = false);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -53,6 +78,11 @@ class _LoginScreenState extends State<LoginScreen> {
               child: isLoading
                   ? const CircularProgressIndicator()
                   : const Text('로그인'),
+            ),
+            const SizedBox(height: 8),
+            OutlinedButton(
+              onPressed: isLoading ? null : _googleLogin,
+              child: const Text('Google로 로그인'),
             ),
             TextButton(
               onPressed: () {

--- a/flutter_application_sajindongnae/lib/screen/auth/register_screen.dart
+++ b/flutter_application_sajindongnae/lib/screen/auth/register_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import '../../main.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -29,8 +30,15 @@ class _RegisterScreenState extends State<RegisterScreen> {
         'nickname': nicknameController.text.trim(),
         'createdAt': DateTime.now(),
       });
-
-      if (mounted) Navigator.pop(context);
+      // 사용자는 회원가입 후 자동으로 로그인된 상태가 됩니다.
+      // 홈 화면(MainPage)으로 이동하며 이전 화면 스택은 모두 제거합니다.
+      if (mounted) {
+        Navigator.pushAndRemoveUntil(
+          context,
+          MaterialPageRoute(builder: (_) => const MainPage()),
+          (route) => false,
+        );
+      }
     } on FirebaseAuthException catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(e.message ?? '회원가입 실패')),

--- a/flutter_application_sajindongnae/pubspec.yaml
+++ b/flutter_application_sajindongnae/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
 
   firebase_core: ^2.32.0
   firebase_auth: ^4.16.0
+  google_sign_in: ^6.2.1
   firebase_storage: ^11.6.5
   cloud_firestore: ^4.17.5
   dropdown_button2: ^2.3.9


### PR DESCRIPTION
## Summary
- request runtime permissions on Android
- add Google sign-in button and logic
- navigate to home after a successful registration

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2e63660832ab16d3dfa3448dd4c